### PR TITLE
Use HTTPS RubyGems source as the :rubygems one is insecure & deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Bundling with the `:rubygems` source prints a warning:

> The source `:rubygems` is deprecated because HTTP requests are insecure.
> Please change your source to `'https://rubygems.org'` if possible, or `'http://rubygems.org'` if not.

This fixes that and switches to HTTPS for security.
