### PR TITLE
Fix Ruby warning about uninitialized instance variable

### DIFF
--- a/lib/pry-rescue/core_ext.rb
+++ b/lib/pry-rescue/core_ext.rb
@@ -33,7 +33,7 @@ class << Pry
   #   end
   #
   def rescued(e=$!)
-    if e.instance_variable_get(:@rescue_bindings)
+    if e.instance_variable_defined?(:@rescue_bindings)
       PryRescue.enter_exception_context(e)
     else
       stack = ''
@@ -73,7 +73,7 @@ class << Pry
   def enable_rescuing!(block=nil)
     Interception.listen(block) do |exception, binding|
       bindings = binding.respond_to?(:callers) ? binding.callers : [binding]
-      unless exception.instance_variable_get(:@rescue_bindings)
+      unless exception.instance_variable_defined?(:@rescue_bindings)
         exception.instance_variable_set(:@rescue_bindings, bindings)
         exception.instance_variable_set(:@rescue_cause, $!)
       end


### PR DESCRIPTION
Instead of trying to get the instance variable and throwing it away to
see if it's there, just check to see if it's there. This fixes the Ruby
warning:

> warning: instance variable @rescue_bindings not initialized
