### PR TITLE
Support Minitest 5 via a separate include file

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,20 @@ code in a way that the `try-again` command can understand. You can still use
 
 ### Minitest
 
-Add the following to your `test_helper.rb` or to the top of your test file.
+Require minitest support in your `test_helper.rb` or to the top of your test file.
+
+For the MiniTest that ships with Ruby 1.9+:
 
 ```ruby
 require 'minitest/autorun'
 require 'pry-rescue/minitest'
+```
+
+For Minitest 5 via the minitest gem:
+
+```ruby
+require 'minitest/autorun'
+require 'pry-rescue/minitest_gem'
 ```
 
 Then, when you have a failure, you can use `edit`, `edit -c`, and `edit-method`, then

--- a/lib/pry-rescue/minitest_gem.rb
+++ b/lib/pry-rescue/minitest_gem.rb
@@ -1,0 +1,14 @@
+require 'pry-rescue'
+
+class Minitest::Test
+  alias_method :run_without_rescue, :run
+
+  # Minitest 5 handles all unknown exceptions, so to get them out of
+  # minitest, we need to add Exception to its passthrough types
+  def run
+    Minitest::Test::PASSTHROUGH_EXCEPTIONS << Exception
+    Pry::rescue do
+      run_without_rescue
+    end
+  end
+end


### PR DESCRIPTION
(This is one of two PRs providing Minitest 5 support, only it or #48 needs to be merged)

By adding a separate include file, the user has to think slightly harder when setting up their project, but the implementation is much cleaner.

I prefer this implementation.
