### PR TITLE
Add ruby 2.1.0 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - rbx-19mode


### PR DESCRIPTION
This should show when the issues in #49 are fixed.
