### PR TITLE
pry-rescue.gemspec: depend on interception v0.4 and higher

### DIFF
--- a/pry-rescue.gemspec
+++ b/pry-rescue.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^bin/}).map{|f| File.basename f}
 
   s.add_dependency 'pry'
-  s.add_dependency 'interception', '>= 0.3'
+  s.add_dependency 'interception', '>= 0.4'
 
   s.add_development_dependency 'pry-stack_explorer' # upgrade to regular dep?
 


### PR DESCRIPTION
v0.4 adds Ruby 2.1.0 support.
