### PR TITLE
Add -i option to pry-rescue

### DIFF
--- a/bin/rescue
+++ b/bin/rescue
@@ -4,7 +4,7 @@ USAGE = %{
 rescue (pry-rescue wrapper)
 
 Usage:
-  rescue [--peek] <script.rb> [arguments...]
+  rescue [-i] <script.rb> [arguments...]
 
 What it does:
   Runs <script.rb>, and if an uncaught exception is raised,
@@ -13,16 +13,23 @@ What it does:
 
   You can then poke around to figure out why your code broke!
 
-  If --peek is specified, then you can hit <Ctrl+C> to interrupt
-  your program and open a pry session at any time you need.
+  If -i is specified, then rescue will open a REPL whether or
+  not there was an exception. Specifying -i will also wrap
+  Kernel.at_exit and run exit callbacks before launching the
+  REPL if the script succeeds. This is useful for minitest and
+  other testing frameworks.
 
   See the README (http://bitly.com/pry-rescue) for more.
 }
+
+ensure_repl = false
+
 case ARGV[0]
 when '-h', '--help'
   puts USAGE
   exit
-when '--'
+when '-i'
+  ensure_repl = true
   ARGV.shift
 when /\A-/
   puts USAGE
@@ -39,7 +46,7 @@ if script = ARGV.shift
   $0 = File.expand_path(script)
   if File.exists? script
     require File.expand_path('../../lib/pry-rescue.rb', __FILE__)
-    PryRescue.load $0
+    PryRescue.load $0, ensure_repl
   else
     $stderr.puts "Error: #{script.inspect} not found."
   end

--- a/lib/pry-rescue/kernel_exit_hooks.rb
+++ b/lib/pry-rescue/kernel_exit_hooks.rb
@@ -1,0 +1,16 @@
+Kernel.class_eval '@@exit_callbacks = []'
+
+Kernel.at_exit { Kernel.run_exit_callbacks }
+
+module Kernel
+  def at_exit(&block)
+    @@exit_callbacks.push block
+  end
+
+  def run_exit_callbacks
+    Pry::rescue do
+      @@exit_callbacks.dup.each &:call
+    end
+    TOPLEVEL_BINDING.pry unless PryRescue.any_exception_captured
+  end
+end


### PR DESCRIPTION
Addresses https://github.com/ConradIrwin/pry-rescue/issues/56 and https://github.com/ConradIrwin/pry-rescue/issues/57.

@robgleeson @ConradIrwin I'd love for you guys to take a look at this.

What I've done:
- Move from Kernel.load to Kernel.eval
- Compensate for losing script-level locals by evalling everything in TOPLEVEL_BINDING (perhaps dangerous? Can we make a sandbox binding?)
- Address syntax errors by just printing them when we see them. As we can't give a meaningful stack trace, don't trying to open a binding at the call site (there really isn't one).
- Hook `Kernel#at_exit` et al when the `-i` flag is specified. Enables some userful behavior:

`rescue -i test.rb` yields:

```
Run options: --seed 42032 

# Running: 

. 

Finished in 0.001498s, 667.4204 runs/s, 667.4204 assertions/s. 

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips 
[1] 2.0.0 > Foo.new.bar 
"whee" 
```

`test.rb`:

```
require 'minitest/autorun'

class Foo
  def bar
    "whee"
  end
end

class TestFoo < MiniTest::Test
  def setup
    @foo = Foo.new
  end

  def test_that_foo_can_bar
    assert_equal "whee", @foo.bar
  end
end
```
