### PR TITLE
Turn on travis bundler caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Speeds up testing new builds dramatically: http://docs.travis-ci.com/user/caching/
