### PR TITLE
Added explicit minitest version check prior to monkeypatching run

### DIFF
--- a/lib/pry-rescue/minitest.rb
+++ b/lib/pry-rescue/minitest.rb
@@ -2,7 +2,9 @@ require 'pry-rescue'
 
 # Minitest 5 handles all unknown exceptions, so to get them out of
 # minitest, we need to add Exception to its passthrough types
-if defined? Minitest::Test
+# Note: We need to check the explicit minitest version because the minitest ecosystem
+# may redefine Minitest::Test for Minitest versions < 5.
+if defined?(Minitest::Test) && Minitest::Unit::VERSION.split('.').first.to_i >= 5
 
   class Minitest::Test
     alias_method :run_without_rescue, :run
@@ -22,7 +24,7 @@ else
   # Unfortunately the version of minitest bundled with ruby seems to
   # take precedence over the new gem, so we can't do this and still
   # support ruby-1.9.3
-  
+
   class MiniTest::Unit::TestCase
     alias_method :run_without_rescue, :run
 


### PR DESCRIPTION
We are using Minitest 4.7.5, but a separate minitest plugin is assigning `Minitest::Test` and the incorrect `run` method is being wrapped.

Adding an explicit Minitest version check to ensure that the correct method is wrapped.
