### PR TITLE
Fix #81 by requiring RSpec

### DIFF
--- a/lib/pry-rescue/rspec.rb
+++ b/lib/pry-rescue/rspec.rb
@@ -1,4 +1,6 @@
 require 'pry-rescue'
+require 'rspec'
+
 class PryRescue
   class RSpec
 


### PR DESCRIPTION
Issue #81 is caused by a NameError:

```
[1] pry(main)> require "pry-rescue/rspec"
NameError: uninitialized constant RSpec from /Library/Ruby/Gems/2.0.0/gems/pry-rescue-1.4.1/lib/pry-rescue/rspec.rb:54:in `<top (required)>'
```

I can't explain why the current way works in RSpec v3.1.x, but with this fix, it will work with v3.1.x and v3.2.x.