### PR TITLE
Delete never used cli.rb

### DIFF
--- a/lib/pry-rescue/cli.rb
+++ b/lib/pry-rescue/cli.rb
@@ -1,1 +1,0 @@
-require 'pry-rescue'


### PR DESCRIPTION
cli.rb is loaded by pry at startup, looking for cli options to add to pry command options.
This file is slowing pry startup by 50%, but it's never used.
It's ok to not exist, since pry checks it:
https://github.com/pry/pry/blob/master/lib/pry/plugins.rb#L38

The same was proposed to pry-byebug:
https://github.com/deivid-rodriguez/pry-byebug/pull/76