### PR TITLE
Require RSpec only when not loaded yet

### DIFF
--- a/lib/pry-rescue/rspec.rb
+++ b/lib/pry-rescue/rspec.rb
@@ -1,5 +1,5 @@
 require 'pry-rescue'
-require 'rspec'
+require 'rspec' unless defined?(RSpec)
 
 class PryRescue
   class RSpec


### PR DESCRIPTION
This PR fixes issue #87 

It checks if rspec is already loaded and if so does not require it.

In issue #87 I use the rspec-rails and don't have the rspec gem in my bundle. Bundler already requires the rspec-rails gem and loads rspec-core, which actually contains (most of) the rspec gem.

An alternative solution would be the following below, but I chose not to do this because you also [check if Capybara loaded](https://github.com/ConradIrwin/pry-rescue/blob/b4bc69f63cee8e0b1f79dd63737147b43724c3ae/lib/pry-rescue/rspec.rb#L38) the same way as in this PR

```diff
 require 'pry-rescue'
-require 'rspec'
+begin
+  require 'rspec'
+rescue LoadError
+  require 'rspec/core'
+end
```