### PR TITLE
Fix usage on a Rails/Rspec binstub (eg. `rescue bin/rspec`)

### DIFF
--- a/bin/rescue
+++ b/bin/rescue
@@ -34,12 +34,15 @@ when '-i'
 when /\A-/
   puts USAGE
   exit
-when 'rails'
-  ENV['PRY_RESCUE_RAILS'] = 'true'
-  exec(*ARGV)
-when /^re?spec|rake$/
-  ENV['SPEC_OPTS'] = "#{ENV['SPEC_OPTS']} -r pry-rescue/rspec"
-  exec(*ARGV)
+else
+  case File.basename(ARGV[0] || "")
+  when 'rails'
+    ENV['PRY_RESCUE_RAILS'] = 'true'
+    exec(*ARGV)
+  when /^re?spec|rake$/
+    ENV['SPEC_OPTS'] = "#{ENV['SPEC_OPTS']} -r pry-rescue/rspec"
+    exec(*ARGV)
+  end
 end
 
 if script = ARGV.shift


### PR DESCRIPTION
Actually, even if I think the code is kinda wonky, I'll make a PR to promote discussion. This is following #86.

This, combined with a custom vim-rspec rescue command hotkey, and I feel like a damn wizard.