### PR TITLE
Update tests to use new expect syntax

### DIFF
--- a/spec/core_ext_spec.rb
+++ b/spec/core_ext_spec.rb
@@ -2,25 +2,25 @@ require File.expand_path('../../lib/pry-rescue.rb', __FILE__)
 
 describe 'Pry.rescue' do
   it 'should call PryRescue.enter_exception_context' do
-    lambda{
-      PryRescue.should_receive(:enter_exception_context).once
+    expect(lambda {
+      expect(PryRescue).to receive(:enter_exception_context).once
       Pry::rescue{ raise "foobar" }
-    }.should raise_error(/foobar/)
+    }).to raise_error(/foobar/)
   end
 
   it "should retry on try-again" do
     @called = 0
-    PryRescue.should_receive(:enter_exception_context).once{ throw :try_again }
+    expect(PryRescue).to receive(:enter_exception_context).once{ throw :try_again }
     Pry::rescue do
       @called += 1
       raise "foobar" if @called == 1
     end
-    @called.should == 2
+    expect(@called).to be(2)
   end
 
   it "should try-again from innermost block" do
     @outer = @inner = 0
-    PryRescue.should_receive(:enter_exception_context).once{ throw :try_again }
+    expect(PryRescue).to receive(:enter_exception_context).once{ throw :try_again }
     Pry::rescue do
       @outer += 1
       Pry::rescue do
@@ -29,13 +29,13 @@ describe 'Pry.rescue' do
       end
     end
 
-    @outer.should == 1
-    @inner.should == 2
+    expect(@outer).to be(1)
+    expect(@inner).to be(2)
   end
 
   it "should enter the first occurence of an exception that is re-raised" do
-    PryRescue.should_receive(:enter_exception_context).once{ |raised| raised.size.should == 1 }
-    lambda do
+    expect(PryRescue).to receive(:enter_exception_context).once{ |raised| raised.size.should == 1 }
+    expect(lambda do
       Pry::rescue do
         begin
           raise "first_occurance"
@@ -43,26 +43,26 @@ describe 'Pry.rescue' do
           raise
         end
       end
-    end.should raise_error(/first_occurance/)
+    end).to raise_error(/first_occurance/)
   end
 
   it "should not catch SystemExit" do
-    PryRescue.should_not_receive(:enter_exception_context)
+    expect(PryRescue).to_not receive(:enter_exception_context)
 
-    lambda do
+    expect(lambda do
       Pry::rescue do
         exit
       end
-    end.should raise_error SystemExit
+    end).to raise_error SystemExit
   end
 
   it 'should not catch Ctrl+C' do
-    PryRescue.should_not_receive(:enter_exception_context)
-    lambda do
+    expect(PryRescue).to_not receive(:enter_exception_context)
+    expect(lambda do
       Pry::rescue do
         raise Interrupt, "ctrl+c (fake)"
       end
-    end.should raise_error Interrupt
+    end).to raise_error Interrupt
   end
 end
 
@@ -72,15 +72,15 @@ describe "Pry.rescued" do
     begin
       raise "foo"
     rescue => e
-      Pry.should_receive(:warn)
+      expect(Pry).to receive(:warn)
       Pry.rescued(e)
     end
   end
 
   it "should raise an error if used on an exception not raised" do
     Pry::rescue do
-      Pry.should_receive(:warn) do |message|
-        message.should =~ /^WARNING: Tried to inspect exception outside of Pry::rescue/
+      expect(Pry).to receive(:warn) do |message|
+        expect(message).to match(/^WARNING: Tried to inspect exception outside of Pry::rescue/)
       end
       Pry.rescued(RuntimeError.new("foo").exception)
     end
@@ -91,7 +91,7 @@ describe "Pry.rescued" do
       begin
         raise "foo"
       rescue => e
-        PryRescue.should_receive(:enter_exception_context).once
+        expect(PryRescue).to receive(:enter_exception_context).once
         Pry::rescued(e)
       end
     end

--- a/spec/peek_spec.rb
+++ b/spec/peek_spec.rb
@@ -6,9 +6,9 @@ describe "PryRescue.peek!" do
     Pry.config.output = StringIO.new
     foo = 5
 
-    lambda do
+    expect(lambda do
       PryRescue.peek!
-    end.should change{ foo }.from(5).to(6)
+    end).to change{ foo }.from(5).to(6)
   end
 
   # this will fail, or not?
@@ -22,8 +22,8 @@ describe "PryRescue.peek!" do
 
     foo = 5
 
-    lambda do
+    expect(lambda do
       PryRescue.peek!
-    end.should change{ foo }.from(5).to(6)
+    end).to change{ foo }.from(5).to(6)
   end
 end

--- a/spec/pry_rescue_spec.rb
+++ b/spec/pry_rescue_spec.rb
@@ -4,52 +4,52 @@ require 'uri'
 describe "PryRescue.load" do
   if defined?(PryStackExplorer)
     it "should open at the correct point" do
-      PryRescue.should_receive(:pry).once{ |opts|
-        opts[:call_stack].first.eval("__FILE__").should end_with('spec/fixtures/simple.rb')
+      expect(PryRescue).to receive(:pry).once { |opts|
+        expect(opts[:call_stack].first.eval("__FILE__")).to end_with('spec/fixtures/simple.rb')
       }
-      lambda{
+      expect(lambda {
         PryRescue.load("spec/fixtures/simple.rb")
-      }.should raise_error(/simple-exception/)
+      }).to raise_error(/simple-exception/)
     end
 
     it "should open above the standard library" do
-      PryRescue.should_receive(:pry).once do |opts|
-        opts[:call_stack][opts[:initial_frame]].eval("__FILE__").should end_with('spec/fixtures/uri.rb')
+      expect(PryRescue).to receive(:pry).once do |opts|
+        expect(opts[:call_stack][opts[:initial_frame]].eval("__FILE__")).to end_with('spec/fixtures/uri.rb')
       end
-      lambda{
+      expect(lambda{
         PryRescue.load("spec/fixtures/uri.rb")
-      }.should raise_error(URI::InvalidURIError)
+      }).to raise_error(URI::InvalidURIError)
     end
 
     it "should keep the standard library on the binding stack" do
-      PryRescue.should_receive(:pry).once do |opts|
-        opts[:call_stack].first.eval("__FILE__").should start_with(RbConfig::CONFIG['libdir'])
+      expect(PryRescue).to receive(:pry).once do |opts|
+        expect(opts[:call_stack].first.eval("__FILE__")).to start_with(RbConfig::CONFIG['libdir'])
       end
-      lambda{
+      expect(lambda{
         PryRescue.load("spec/fixtures/uri.rb")
-      }.should raise_error(URI::InvalidURIError)
+      }).to raise_error(URI::InvalidURIError)
     end
 
     it "should open above gems" do
-      PryRescue.should_receive(:pry).once do |opts|
-        opts[:call_stack][opts[:initial_frame]].eval("__FILE__").should end_with('spec/fixtures/coderay.rb')
+      expect(PryRescue).to receive(:pry).once do |opts|
+        expect(opts[:call_stack][opts[:initial_frame]].eval("__FILE__")).to end_with('spec/fixtures/coderay.rb')
       end
-      lambda{
+      expect(lambda{
         PryRescue.load("spec/fixtures/coderay.rb")
-      }.should raise_error(ArgumentError)
+      }).to raise_error(ArgumentError)
     end
 
     it "should open above gems" do
-      PryRescue.should_receive(:pry).once do |opts|
+      expect(PryRescue).to receive(:pry).once do |opts|
         coderay_path = Gem::Specification.respond_to?(:detect) ?
                          Gem::Specification.detect{|x| x.name == 'coderay' }.full_gem_path :
                          Gem.all_load_paths.grep(/coderay/).last
 
-        opts[:call_stack].first.eval("__FILE__").should start_with(coderay_path)
+        expect(opts[:call_stack].first.eval("__FILE__")).to start_with(coderay_path)
       end
-      lambda{
+      expect(lambda{
         PryRescue.load("spec/fixtures/coderay.rb")
-      }.should raise_error(ArgumentError)
+      }).to raise_error(ArgumentError)
     end
 
     it "should skip pwd, even if it is a gem (but not vendor stuff)" do
@@ -66,56 +66,56 @@ describe "PryRescue.load" do
     end
 
     it "should filter out duplicate stack frames" do
-      PryRescue.should_receive(:pry).once do |opts|
-        opts[:call_stack][0].eval("__LINE__").should == 4
-        opts[:call_stack][1].eval("__LINE__").should == 12
+      expect(PryRescue).to receive(:pry).once do |opts|
+        expect(opts[:call_stack][0].eval("__LINE__")).to be(4)
+        expect(opts[:call_stack][1].eval("__LINE__")).to be(12)
       end
-      lambda{
+      expect(lambda{
         PryRescue.load("spec/fixtures/super.rb")
-      }.should raise_error(/super-exception/)
+      }).to raise_error(/super-exception/)
     end
 
     it "should calculate correct initial frame even when duplicates are present" do
-      PryRescue.should_receive(:pry).once do |opts|
-        opts[:call_stack][0].eval("__FILE__").should end_with('fake.rb')
-        opts[:call_stack][opts[:initial_frame]].eval("__FILE__").should end_with('spec/fixtures/initial.rb')
+      expect(PryRescue).to receive(:pry).once do |opts|
+        expect(opts[:call_stack][0].eval("__FILE__")).to end_with('fake.rb')
+        expect(opts[:call_stack][opts[:initial_frame]].eval("__FILE__")).to end_with('spec/fixtures/initial.rb')
       end
-      lambda{
+      expect(lambda{
         PryRescue.load("spec/fixtures/initial.rb")
-      }.should raise_error(/no :baz please/)
+      }).to raise_error(/no :baz please/)
     end
 
     it "should skip over reraises from within gems" do
-      PryRescue.should_receive(:pry).once do |opts|
-        opts[:call_stack][0].eval("__FILE__").should end_with('spec/fixtures/reraise.rb')
+      expect(PryRescue).to receive(:pry).once do |opts|
+        expect(opts[:call_stack][0].eval("__FILE__")).to end_with('spec/fixtures/reraise.rb')
       end
-      lambda{
+      expect(lambda{
         PryRescue.load("spec/fixtures/reraise.rb")
-      }.should raise_error(/reraise-exception/)
+      }).to raise_error(/reraise-exception/)
     end
 
     it "should not skip over independent raises within gems" do
-      PryRescue.should_receive(:pry).once do |opts|
-        opts[:call_stack][0].eval("__FILE__").should end_with('fake.rb')
+      expect(PryRescue).to receive(:pry).once do |opts|
+        expect(opts[:call_stack][0].eval("__FILE__")).to end_with('fake.rb')
       end
-      lambda{
+      expect(lambda{
         PryRescue.load("spec/fixtures/raiseother.rb")
-      }.should raise_error(/raiseother_exception/)
+      }).to raise_error(/raiseother_exception/)
     end
 
     it "should output a warning if the exception was not raised" do
-      PryRescue.should_not_receive(:enter_exception_context)
-      Pry.should_receive(:warn).once
+      expect(PryRescue).to_not receive(:enter_exception_context)
+      expect(Pry).to receive(:warn).once
       Pry.rescued(RuntimeError.new("foo"))
     end
   else
     it "should open at the correct point" do
-      Pry.should_receive(:start).once{ |binding, h|
-        binding.eval("__FILE__").should end_with('spec/fixtures/simple.rb')
+      expect(Pry).to receive(:start).once { |binding, h|
+        expect(binding.eval("__FILE__")).to end_with('spec/fixtures/simple.rb')
       }
-      lambda{
+      expect(lambda{
         PryRescue.load("spec/fixtures/simple.rb")
-      }.should raise_error(/simple-exception/)
+      }).to raise_error(/simple-exception/)
     end
   end
 end


### PR DESCRIPTION
Hello!!

I've started working on #89 and when launching tests I've been getting a lot of warnings about deprecated rspec expectation method `should` in favor of `expect`

So I've updated tests to use new expectacion method `expect`