### PR TITLE
Get original exception in case of re-raise

### DIFF
--- a/lib/pry-rescue/commands.rb
+++ b/lib/pry-rescue/commands.rb
@@ -47,6 +47,8 @@ Pry::Commands.create_command "cd-cause", "Move to the exception that caused this
     ex = ex.instance_variable_get(:@rescue_cause) if rescued == ex
     raise Pry::CommandError, "No previous exception to cd-cause into" if ex.nil? || ex == rescued
 
+    ex = ex.cause if ex.respond_to?(:cause) && !ex.cause.nil?
+
     Pry.rescued ex
   end
 end

--- a/spec/fixtures/template_error.rb
+++ b/spec/fixtures/template_error.rb
@@ -1,3 +1,8 @@
+# This Exception Class behaves same as ActionView::Template::Error
+# https://github.com/rails/rails/blob/master/actionview/lib/action_view/template/error.rb#L68
+#
+# It encapsulates an Exception and stores the latest Exception raised in its
+# `cause` attribute
 class TemplateError < StandardError
   attr_reader :cause
 

--- a/spec/fixtures/template_error.rb
+++ b/spec/fixtures/template_error.rb
@@ -1,0 +1,8 @@
+class TemplateError < StandardError
+  attr_reader :cause
+
+  def initialize(cause)
+    @cause = $!
+  end
+end
+


### PR DESCRIPTION
Hello!

I've recently discovered this gem and I love it! But unfortunately when I was testing it out in my Rails project I got to the point where I faced an error in one of my views and after checking the project's issues I found #89 :(

After learning about Rails `Template::Error` class I have found that the original exception is stored in its attribute `cause` so in order to `cd` to that exception I have modified your `cd-cause` method to check if there is a `cause` exception and in that case `cd` there.

Rails source about what I am talking about:
https://github.com/rails/rails/blob/master/actionview/lib/action_view/template/error.rb#L68

Tests are passing and I have tested against @yar sample project too, https://github.com/yar/p-r-test

Now you can `cd-cause` correctly to the root of the problem and see what is happening

(@yar post https://github.com/ConradIrwin/pry-rescue/issues/89#issuecomment-130385894)