### PR TITLE
Remove test breaking requirement

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
 require 'rspec'
 
-require 'pry/test/helper'
-
 require './lib/pry-rescue'


### PR DESCRIPTION
Avoid

```
An error occurred while loading ./spec/commands_spec.rb.
Failure/Error: require 'pry/test/helper'

LoadError:
  cannot load such file -- pry/test/helper

Finished in 0.00017 seconds (files took 0.43596 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```