### PR TITLE
Fix REPL not opening for rake tasks.  Closes #74

### DIFF
--- a/bin/rescue
+++ b/bin/rescue
@@ -39,7 +39,11 @@ else
   when 'rails'
     ENV['PRY_RESCUE_RAILS'] = 'true'
     exec(*ARGV)
-  when /^re?spec|rake$/
+  when 'rake'
+    require File.expand_path('../../lib/pry-rescue.rb', __FILE__)
+    PryRescue.load_rake ARGV[1]
+    exit
+  when /^re?spec$/
     ENV['SPEC_OPTS'] = "#{ENV['SPEC_OPTS']} -r pry-rescue/rspec"
     exec(*ARGV)
   end

--- a/lib/pry-rescue.rb
+++ b/lib/pry-rescue.rb
@@ -79,6 +79,14 @@ class PryRescue
       end
     end
 
+    def load_rake(task)
+      require 'rake'
+      Pry::rescue do
+        load "#{Dir.pwd}/Rakefile"
+        Rake::Task[task].invoke
+      end
+    end
+
     # Is the user currently inside pry rescue?
     # @return [Boolean]
     def in_exception_context?


### PR DESCRIPTION
This gem was not opening a REPL when running rake tasks. Here's a minimal rails 5 repo that reproduces the issue:

https://github.com/abaldwin88/pry-rescue-bug