### PR TITLE
bin/rescue: use the realpath

### DIFF
--- a/bin/rescue
+++ b/bin/rescue
@@ -52,7 +52,7 @@ end
 if script = ARGV.shift
   $0 = File.expand_path(script)
   if File.exists? script
-    require File.expand_path('../../lib/pry-rescue.rb', __FILE__)
+    require File.realpath(File.expand_path('../../lib/pry-rescue.rb', __FILE__))
     PryRescue.load $0, ensure_repl
   else
     $stderr.puts "Error: #{script.inspect} not found."

--- a/bin/rescue
+++ b/bin/rescue
@@ -40,7 +40,7 @@ else
     ENV['PRY_RESCUE_RAILS'] = 'true'
     exec(*ARGV)
   when 'rake'
-    require File.expand_path('../../lib/pry-rescue.rb', __FILE__)
+    require File.realpath(File.expand_path('../../lib/pry-rescue.rb', __FILE__))
     PryRescue.load_rake ARGV[1]
     exit
   when /^re?spec$/
@@ -51,6 +51,7 @@ end
 
 if script = ARGV.shift
   $0 = File.expand_path(script)
+
   if File.exists? script
     require File.realpath(File.expand_path('../../lib/pry-rescue.rb', __FILE__))
     PryRescue.load $0, ensure_repl


### PR DESCRIPTION
This fixes issue #109.

Since ruby 2.5, `require 'pry-rescue'` uses the realpath of the
pry-rescue gem. But `bin/rescue` specify an absolute path to load
'pry-rescue'.

So if 'pry-rescue' is in a path that contains a symlink, it will be
loaded twice, once from `bin/rescue` (at the absolute path)
and the other one via 'pry' automatic loading of plugins (at the real
path).

Then the pry hooks will be called twice, which yield an error.
See also https://github.com/pry/pry/pull/1762