### PR TITLE
Fix undefined method `windows?'

### DIFF
--- a/lib/pry-rescue.rb
+++ b/lib/pry-rescue.rb
@@ -12,7 +12,7 @@ if ENV['PRY_RESCUE_RAILS']
 end
 case ENV['PRY_PEEK']
 when nil
-  PryRescue.peek_on_signal('QUIT') unless Pry::Helpers::BaseHelpers.windows?
+  PryRescue.peek_on_signal('QUIT') unless Pry::Helpers::Platform.windows?
 when ''
   # explicitly disable QUIT.
 else


### PR DESCRIPTION
This fixes an incompatibility with current pry HEAD, which apparently retired Pry::Platform. 

I fear this fix by itself would again be incompatible with current pry *release* version. But I don't know enough about the respective releases processes, and which strategy you tend to prefer (set dependency to next pry release/```respond_to?```/etc.).

Feel free to close and/or adapt as you see fit.