### PR TITLE
Stop using deprecated BaseHelpers#windows

### DIFF
--- a/lib/pry-rescue.rb
+++ b/lib/pry-rescue.rb
@@ -12,7 +12,7 @@ if ENV['PRY_RESCUE_RAILS']
 end
 case ENV['PRY_PEEK']
 when nil
-  PryRescue.peek_on_signal('QUIT') unless Pry::Helpers::BaseHelpers.windows?
+  PryRescue.peek_on_signal('QUIT') unless Pry::Helpers::::Platform.windows?
 when ''
   # explicitly disable QUIT.
 else


### PR DESCRIPTION
Pry 0.12 deprecated calling `windows?` on BaseHelper, so we should update this to silence the deprecation. We perhaps should also bump the pry dependency version.