### PR TITLE
Require 'pry-stack_explorer' from lib/pry-rescue/rspec.rb

### DIFF
--- a/lib/pry-rescue/rspec.rb
+++ b/lib/pry-rescue/rspec.rb
@@ -1,4 +1,5 @@
 require 'pry-rescue'
+require 'pry-stack_explorer'
 require 'rspec' unless defined?(RSpec)
 
 class PryRescue


### PR DESCRIPTION
... since it seems to be needed to correctly identify the correct frame that the test failure
exception occurred in.

Resolves #98