### PR TITLE
RSpec: Fix transactional tests (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* RSpec: Fix Rescue opening after transactional tests are rolled back.
+(issue #99 - PR #118)
+
 * bin/rescue: Use realpaths (issue #109 - PR #110)
 
   *(Damien Robert)*

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ browser on unhandled exceptions, and [pry-rails](https://github.com/rweng/pry-ra
 adds some Rails specific helpers to Pry, and replaces `rails console` by Pry.
 
 ### RSpec
-**ActiveRecord users: see below caveat**
 
 If you're using [RSpec](https://rspec.org) or
 [respec](https://github.com/oggy/respec), you can open a Pry session on
@@ -106,26 +105,10 @@ RSpec::Expectations::ExpectationNotMetError: expected: 0.3
 [1] pry(main)>
 ```
 
-### Important caveat when using with Rails/ActiveRecord and transactional fixtures
-> Records are missing but should be there! Am I losing track of reality?
-
-You are not. (Probably.)
-
-By default, RSpec runs test examples in a transaction, and rolls it back when done.
-By the time Pry-Rescue fires, the transaction has already been rolled back and records are gone!
-
-A good sanity check is to call `Model.all`. It will usually be empty. However, at the time of the test, they were truly there.
-
-This bug is currently tracked at [#99](https://github.com/ConradIrwin/pry-rescue/issues/99).
-
-Current workaround: Pry-Rescue can't be used, but you can use `binding.pry` inside the test. You'll have access to all records you need there.
-
-### Using pry `edit`
 Unfortunately using `edit -c` to edit `_spec.rb` files does not yet reload the
 code in a way that the `try-again` command can understand. You can still use
 `try-again` if you edit code that is not in spec files.
 
-### Always enabled
 If you want pry-rescue to *always* be enabled when you run tests, simply add this line to your `test_helper.rb`:
 
 ```ruby

--- a/lib/pry-rescue/rspec.rb
+++ b/lib/pry-rescue/rspec.rb
@@ -16,12 +16,7 @@ class PryRescue
           before
 
           example.example.instance_variable_set(:@exception, nil)
-
-          if example.example_group_instance.respond_to?(:__init_memoized, true)
-            example.example_group_instance.instance_variable_set(:@__init_memoized, true)
-          else
-            example.example_group_instance.instance_variable_set(:@__memoized, {})
-          end
+          example.example_group_instance.instance_variable_set(:@__init_memoized, true)
 
           example.run
 


### PR DESCRIPTION
Rescues in :after hook instead of :around

Fixes #99.

(Pry-Stackexplorer really shined here)

Includes some satisfying cleanup

Touches code by @magicalbanana @ConradIrwin @jacob-carlborg 