### PR TITLE
Update Capybara monkey patch to check Capybara.raise_server_errors

### DIFF
--- a/lib/pry-rescue/rspec.rb
+++ b/lib/pry-rescue/rspec.rb
@@ -50,7 +50,13 @@ class PryRescue
       unless Capybara.respond_to?(:reset_sessions_after_rescue!)
         class << Capybara
           alias_method :reset_sessions_after_rescue!, :reset_sessions!
-          def reset_sessions!; end
+          def reset_sessions!
+            return if Capybara.raise_server_errors
+
+            session_pool.reverse_each do |_mode, session|
+              session.server.reset_error!
+            end
+          end
         end
 
         after_filters << Capybara.method(:reset_sessions_after_rescue!)


### PR DESCRIPTION
If `Capybara.raise_server_errors` is temporarily disabled for a spec,
reset each session's errors to prevent `reset_sessions_after_rescue!`
from raising an error after `raise_server_errors` has been reset.

Fixes #127.
